### PR TITLE
Prepend branch name with repository name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ POLL_TIMEOUT=${POLL_TIMEOUT:-$DEFAULT_POLL_TIMEOUT}
 
 git checkout "${GITHUB_REF:11}"
 
-branch=$(git symbolic-ref --short HEAD)
+branch=${GITHUB_REPOSITORY}/$(git symbolic-ref --short HEAD)
 
 sh -c "git config --global credential.username $GITLAB_USERNAME"
 sh -c "git config --global core.askPass /cred-helper.sh"
@@ -17,6 +17,9 @@ sh -c "echo pushing to $branch branch at $(git remote get-url --push mirror)"
 sh -c "git push mirror $branch"
 
 sleep $POLL_TIMEOUT
+
+# convert slashes in a HTML-compatible way
+branch=${branch//\//%2F}
 
 pipeline_id=$(curl --header "PRIVATE-TOKEN: $GITLAB_PASSWORD" --silent "https://${GITLAB_HOSTNAME}/api/v4/projects/${GITLAB_PROJECT_ID}/repository/commits/${branch}" | jq '.last_pipeline.id')
 


### PR DESCRIPTION
We are also using the workflow with a `GitHub` repository with multiple people and have multiple forks. Since `GitHub` doesn't allow secrets to be accessed in pull requests, we rely on this workflow running on the respective branches in the forks.
In order to avoid pushing branches with the same name to `GitLab` from multiple forks, it's useful to prepend the branch name with the repository name which is what this pull request does.
Unfortunately, the resulting branch name contains slahes that need to be converted in a HTML-compatible way.