### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ jobs:
         GITLAB_HOSTNAME: "gitlab.com"
         GITLAB_USERNAME: "svboxel"
         GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }} // Generate here: https://gitlab.com/profile/personal_access_tokens
-        GITLAB_PROJECT_ID: "<GitLab project ID>"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
+        GITLAB_PROJECT_ID: "<GitLab project ID>" // https://gitlab.com/<namespace>/<repository>/edit
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
 ```
 
 Be sure to define the `GITLAB_PASSWORD` secret in `https://github.com/<namespace>/<repository>/settings/secrets`  


### PR DESCRIPTION
The link provided:
https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret

doesn't work anymore.

I think it should be replaced with:
https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret

Side question: is there any setting of `GITHUB_TOKEN` required?