### PR TITLE
Force push

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ sh -c "git config --global core.askPass /cred-helper.sh"
 sh -c "git config --global credential.helper cache"
 sh -c "git remote add mirror $*"
 sh -c "echo pushing to $branch branch at $(git remote get-url --push mirror)"
-sh -c "git push mirror $branch"
+sh -c "git push mirror $branch --force"
 
 sleep $POLL_TIMEOUT
 


### PR DESCRIPTION
`Force` is mandatory if there are git history changes (after rebasing a branch for example)