### PR TITLE
Fix crash when the FORCE_PUSH variable is not set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ sh -c "git config --global core.askPass /cred-helper.sh"
 sh -c "git config --global credential.helper cache"
 sh -c "git remote add mirror $*"
 sh -c "echo pushing to $branch branch at $(git remote get-url --push mirror)"
-if [ "$FORCE_PUSH" = "true" ]
+if [ "${FORCE_PUSH:-}" = "true" ]
 then
   sh -c "git push --force mirror $branch"
 else


### PR DESCRIPTION
Sorry about this, but it appears I broke it! Bash is not my string suite...

The script crashed when FORCE_PUSH was not set because I didn't expand it with a default.