### PR TITLE
Specify safe directory to mitigate dubious ownership issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,7 @@ branch="$(git symbolic-ref --short HEAD)"
 branch_uri="$(urlencode ${branch})"
 
 sh -c "git config --global credential.username $GITLAB_USERNAME"
+sh -c "git config --global --add safe.directory /github/workspace"
 sh -c "git config --global core.askPass /cred-helper.sh"
 sh -c "git config --global credential.helper cache"
 sh -c "git remote add mirror $*"


### PR DESCRIPTION
##Specify safe directory to mitigate dubious ownership issue

Github workflow started crashing as described in #21 . This change is aimed to remediate the issue.

I was not able to test it locally - @SvanBoxel are you able to build a preview version of this action to check if it works after the fix?
