### PR TITLE
Specify safe directory earlier in the code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,13 +21,13 @@ urlencode() (
 DEFAULT_POLL_TIMEOUT=10
 POLL_TIMEOUT=${POLL_TIMEOUT:-$DEFAULT_POLL_TIMEOUT}
 
+sh -c "git config --global --add safe.directory /github/workspace"
 git checkout "${GITHUB_REF:11}"
 
 branch="$(git symbolic-ref --short HEAD)"
 branch_uri="$(urlencode ${branch})"
 
 sh -c "git config --global credential.username $GITLAB_USERNAME"
-sh -c "git config --global --add safe.directory /github/workspace"
 sh -c "git config --global core.askPass /cred-helper.sh"
 sh -c "git config --global credential.helper cache"
 sh -c "git remote add mirror $*"


### PR DESCRIPTION
## Description

I added the same code snippet but earlier in the entrypoint.sh. This fixes issue #21 . @SvanBoxel  please see if you are ok with formatting after the change. Thank you!

## Tests
This time I managed to test it in my environment.

### Before fix
GH Action failing just after initialization with:
`fatal: detected dubious ownership in repository at '/github/workspace'`

### After fix
All works properly - tested on fork klinkeklinke/gitlab-mirror-and-ci-action@master.