### PR TITLE
Use `$GITHUB_REF_NAME` to work with both branches and tags.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ DEFAULT_POLL_TIMEOUT=10
 POLL_TIMEOUT=${POLL_TIMEOUT:-$DEFAULT_POLL_TIMEOUT}
 
 sh -c "git config --global --add safe.directory /github/workspace"
-git checkout "${GITHUB_REF:11}"
+git checkout "$GITHUB_REF_NAME"
 
 branch="$(git symbolic-ref --short HEAD)"
 branch_uri="$(urlencode ${branch})"


### PR DESCRIPTION
#24 

The old code assumed we were trimming off the string `refs/heads/` (11 letters) but when triggered by a tag, the string to trim is `refs/tags/` (10 letters) causing the workflow to fail.

$GITHUB_REF_NAME is the short name (without `refs/heads` or `refs/tags`) so should work in both cases. ([source](https://docs.github.com/en/actions/learn-github-actions/variables)). 
